### PR TITLE
Update .vimrc

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -84,7 +84,7 @@ endif
 let &t_SI = "\<Esc>Ptmux;\<Esc>\<Esc>]50;CursorShape=1\x7\<Esc>\\"
 let &t_SR = "\<Esc>Ptmux;\<Esc>\<Esc>]50;CursorShape=2\x7\<Esc>\\"
 let &t_EI = "\<Esc>Ptmux;\<Esc>\<Esc>]50;CursorShape=0\x7\<Esc>\\"
-let $NVIM_TUI_ENABLE_CURSOR_SHAPE=1
+
 "========================================================
 " CONFIG AIRLINE
 "========================================================


### PR DESCRIPTION
This setting is deprecated in latest version of Neovim https://github.com/neovim/neovim/wiki/FAQ#how-to-change-cursor-shape-in-the-terminal